### PR TITLE
feat: add vault address to settle instruction

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -126,6 +126,7 @@ contract Vault is Initializable, UUPSUpgradeable, AccessControlUpgradeable, Reen
     struct SettleData {
         Universe universe; // Universe where settlement occurs
         uint256 chainID; // Chain where settlement occurs
+        address vaultAddress; // Vault address to call "settle()" on.
         address[] solvers; // Addresses of solvers to pay
         address[] contractAddresses; // Token contracts (address(0) for ETH)
         uint256[] amounts; // Payment amounts for each solver
@@ -388,6 +389,7 @@ contract Vault is Initializable, UUPSUpgradeable, AccessControlUpgradeable, Reen
         require(!settleNonce[settleData.nonce], "Vault: Nonce already used");
         require(settleData.chainID == block.chainid, "Vault: Chain ID mismatch");
         require(settleData.universe == Universe.ETHEREUM, "Vault: Universe mismatch");
+        require(settleData.vaultAddress == address(this), "Vault: Invalid vault address");
 
         settleNonce[settleData.nonce] = true;
         for (uint256 i = 0; i < settleData.solvers.length; ++i) {

--- a/test/BaseVaultTest.t.sol
+++ b/test/BaseVaultTest.t.sol
@@ -216,6 +216,7 @@ abstract contract BaseVaultTest is Test {
     /// @notice Creates a SettleData struct for testing
     /// @param universe Universe where settlement occurs
     /// @param chainId Chain where settlement occurs
+    /// @param vaultAddress Address of the vault contract
     /// @param solvers Array of solver addresses to pay
     /// @param contractAddresses Array of token contract addresses (address(0) for ETH)
     /// @param amounts Array of payment amounts
@@ -224,6 +225,7 @@ abstract contract BaseVaultTest is Test {
     function _createSettleData(
         Vault.Universe universe,
         uint256 chainId,
+        address vaultAddress,
         address[] memory solvers,
         address[] memory contractAddresses,
         uint256[] memory amounts,
@@ -232,6 +234,7 @@ abstract contract BaseVaultTest is Test {
         return Vault.SettleData({
             universe: universe,
             chainID: chainId,
+            vaultAddress: vaultAddress,
             solvers: solvers,
             contractAddresses: contractAddresses,
             amounts: amounts,
@@ -259,7 +262,7 @@ abstract contract BaseVaultTest is Test {
         uint256[] memory amounts = new uint256[](1);
         amounts[0] = amount;
 
-        return _createSettleData(Vault.Universe.ETHEREUM, block.chainid, solvers, contractAddresses, amounts, nonce);
+        return _createSettleData(Vault.Universe.ETHEREUM, block.chainid, address(vault), solvers, contractAddresses, amounts, nonce);
     }
 
     // Helper Functions - Address Conversion

--- a/test/Vault.fuzz.t.sol
+++ b/test/Vault.fuzz.t.sol
@@ -446,7 +446,7 @@ contract VaultFuzzTest is BaseVaultTest {
         amounts[1] = amount2;
 
         Vault.SettleData memory settleData =
-            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, solvers, contractAddresses, amounts, nonce);
+            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, address(vault), solvers, contractAddresses, amounts, nonce);
 
         // Sign with verifier key
         bytes32 structHash = keccak256(

--- a/test/unit/Vault/AccessControl.t.sol
+++ b/test/unit/Vault/AccessControl.t.sol
@@ -183,7 +183,7 @@ contract AccessControlTest is BaseVaultTest {
         amounts[1] = 0.5 ether;
 
         Vault.SettleData memory settleData =
-            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, solvers, contractAddresses, amounts, nonce);
+            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, address(vault), solvers, contractAddresses, amounts, nonce);
 
         bytes32 structHash = keccak256(
             abi.encode(
@@ -221,7 +221,7 @@ contract AccessControlTest is BaseVaultTest {
         amounts[0] = 0.5 ether;
 
         Vault.SettleData memory settleData =
-            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, solvers, contractAddresses, amounts, nonce);
+            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, address(vault), solvers, contractAddresses, amounts, nonce);
 
         bytes32 structHash = keccak256(
             abi.encode(
@@ -293,6 +293,7 @@ contract AccessControlTest is BaseVaultTest {
         Vault.SettleData memory settleData = _createSettleData(
             Vault.Universe.ETHEREUM,
             999999, // Wrong chainID
+            address(vault),
             solvers,
             contractAddresses,
             amounts,
@@ -326,6 +327,7 @@ contract AccessControlTest is BaseVaultTest {
         Vault.SettleData memory settleData = _createSettleData(
             Vault.Universe.SOLANA, // Wrong universe
             block.chainid,
+            address(vault),
             _toAddressArray(solver),
             _toAddressArray(address(0)),
             _toUintArray(settleAmount),

--- a/test/unit/Vault/VaultCore.t.sol
+++ b/test/unit/Vault/VaultCore.t.sol
@@ -875,7 +875,7 @@ contract VaultCoreTest is BaseVaultTest {
         amounts[1] = 1000 * 10 ** 18;
 
         Vault.SettleData memory settleData =
-            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, solvers, contractAddresses, amounts, nonce);
+            _createSettleData(Vault.Universe.ETHEREUM, block.chainid, address(vault), solvers, contractAddresses, amounts, nonce);
 
         // Sign with verifier key
         bytes32 structHash = keccak256(


### PR DESCRIPTION
According to comment on https://github.com/availproject/nexus-v2/pull/276/changes#diff-769bf017ffb8d1560e7679f33e5a9a86b745215f82336d1e9269c342696b9cf7R38

```
    /// Vault contract address to call `settle()` on (H256, EVM address in bytes[12..32]).
    /// Routes the settlement to the correct vault when a chain has multiple vaults.
    /// Not included in the on-chain signing hash (the Solidity struct omits it).
```

This PR doesn't' include the vault address in the signature. 

The vault does compare its own address to the one mentioned in the settlement instruction.